### PR TITLE
Honeycomb Menu NG v0.1 foundation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,31 @@
+name: Build Honeycomb Menu NG
+
+on:
+  push:
+    branches:
+      - master
+      - feature/**
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Verify build output
+        run: test -f honeycomb-menu-ng.js

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,3 +31,9 @@ jobs:
 
       - name: Verify build output
         run: test -f honeycomb-menu-ng.js
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: honeycomb-menu-ng
+          path: honeycomb-menu-ng.js

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,8 @@ jobs:
         run: npm ci
 
       - name: Build
+        env:
+          NODE_OPTIONS: --openssl-legacy-provider
         run: npm run build
 
       - name: Verify build output

--- a/README.md
+++ b/README.md
@@ -1,5 +1,13 @@
-# Honeycomb-Menu for Home Assistant by [@Sian-Lee-SA](http://github.com/Sian-Lee-SA)
+# Honeycomb Menu NG for Home Assistant
+Enhanced fork of Sian-Lee-SA/honeycomb-menu.
 
+Goals:
+- Flexible 1–10 button layouts
+- Global button defaults/styling
+- Mouse hover activation
+- Touch drag activation
+- Improved nested honeycomb menus
+- Backwards compatibility with existing honeycomb-menu YAML
 
 <a href="https://www.paypal.com/donate/?business=A82MM255CXF9L&no_recurring=0&item_name=Donating+will+help+justify+my+time+coding+and+doing+projects+that+also+benifits+others.+Any+amount+is+greatly+appreciated%21&currency_code=AUD"><img src="https://github.com/andreostrovsky/donate-with-paypal/raw/master/blue.svg" height="38"></a>
 [![Buy Me A Coffee](https://www.buymeacoffee.com/assets/img/custom_images/orange_img.png)](https://www.buymeacoffee.com/SianLee)

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,5 @@
 {
-  "name": "Honeycomb Menu",
+  "name": "Honeycomb Menu NG",
   "content_in_root": true,
   "filename": "honeycomb-menu.js",
   "render_readme": true

--- a/hacs.json
+++ b/hacs.json
@@ -1,6 +1,6 @@
 {
   "name": "Honeycomb Menu NG",
   "content_in_root": true,
-  "filename": "honeycomb-menu.js",
+  "filename": "honeycomb-menu-ng.js",
   "render_readme": true
 }

--- a/package.json
+++ b/package.json
@@ -1,16 +1,16 @@
 {
-    "name": "honeycomb-menu",
-    "private": true,
-    "version": "0.14.8",
-    "description": "Display a popup menu for Home Assistant lovelace cards via tap, hold or double tap",
+  "name": "honeycomb-menu-ng",
+  "private": true,
+  "version": "0.1.0",
+  "description": "Enhanced Honeycomb popup menu for Home Assistant with flexible layouts, shared styling and improved interaction.",
     "scripts": {
         "build": "webpack",
         "watch": "webpack --watch --mode=development"
     },
-    "repository": {
-        "type": "git",
-        "url": "github.com:Sian-Lee-SA/honeycomb-menu"
-    },
+  "repository": {
+    "type": "git",
+    "url": "github.com:NicolaiTandrup/honeycomb-menu-ng"
+  },
     "author": "Sian Croser",
     "license": "GPLv3",
     "devDependencies": {

--- a/src/honeycomb-menu.js
+++ b/src/honeycomb-menu.js
@@ -313,7 +313,8 @@ class HoneycombMenu extends LitElement
             variables: {},
             size: 225,
             spacing: 2,
-            animation_speed: 100
+            animation_speed: 100,
+			button_defaults: {}
         });
         this.config = config;
         // These aren't perfect calculations but produces the result we want
@@ -540,7 +541,23 @@ class HoneycombMenu extends LitElement
     {
         if( isEmpty(item) )
             return item;
-        return omit( merge( {}, this.config, item ), ['buttons', 'size', 'action', 'xy_pad', 'spacing'] );
+
+        return omit(
+            merge(
+                {},
+                this.config,
+                this.config.button_defaults || {},
+                item
+            ),
+            [
+                'buttons',
+                'size',
+                'action',
+                'xy_pad',
+                'spacing',
+                'button_defaults'
+            ]
+        );
     }
 
     _computeAnimateDelay( i )

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -13,7 +13,7 @@ module.exports = {
     entry: './src/honeycomb-menu.js',
     mode: 'production',
     output: {
-        filename: 'honeycomb-menu.js',
+        filename: 'honeycomb-menu-ns.js',
         path: path.resolve(__dirname)
     }
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -13,7 +13,7 @@ module.exports = {
     entry: './src/honeycomb-menu.js',
     mode: 'production',
     output: {
-        filename: 'honeycomb-menu-ns.js',
+        filename: 'honeycomb-menu-ng.js',
         path: path.resolve(__dirname)
     }
 };


### PR DESCRIPTION
Initial Honeycomb Menu NG foundation.

Changes:
- Rename project/package/HACS identity
- Separate NG build output
- Add global button_defaults support
- Add GitHub Actions build workflow
- Upload build artifact